### PR TITLE
Fix bug in script related to hosts which were migrated from packages

### DIFF
--- a/hue_migrate_queries.sh
+++ b/hue_migrate_queries.sh
@@ -17,7 +17,7 @@ then
   fi
 fi
 
-if [ ! -d "/usr/lib/hadoop" ]
+if [ -d "$PARCEL_DIR/" ]
 then
    CDH_HOME=$PARCEL_DIR
 else


### PR DESCRIPTION
Systems migrated from packages to parcels will have /usr/lib/hadoop
while no systems with packages will have a valid parcel installed.